### PR TITLE
Adding constants for FamilyType, Verdict, and AnalysisStatusCode

### DIFF
--- a/intezer_sdk/consts.py
+++ b/intezer_sdk/consts.py
@@ -10,6 +10,7 @@ class AnalysisStatusCode(Enum):
     QUEUED = 'queued'
     FAILED = 'failed'
     FINISH = 'finished'
+    SUCCEEDED = 'succeeded'
 
 
 class IndexStatusCode(Enum):
@@ -35,6 +36,24 @@ class IndexType(Enum):
 class CodeItemType(Enum):
     FILE = 'file'
     MEMORY_MODULE = 'memory_module'
+
+
+class FamilyType(Enum):
+    ADMINISTRATION_TOOL = 'administration_tool'
+    APPLICATION = 'application'
+    INSTALLER = 'installer'
+    INTERPRETER = 'interpreter'
+    LIBRARY = 'library'
+    MALWARE = 'malware'
+    PACKER = 'packer'
+
+
+class Verdict(Enum):
+    KNOWN_MALICIOUS = 'known_malicious'
+    MALICIOUS = 'malicious'
+    SUSPICIOUS = 'suspicious'
+    TRUSTED = 'trusted'
+    UNKNOWN = 'unknown'
 
 
 class OnPremiseVersion(IntEnum):


### PR DESCRIPTION
The "succeeded" status code is missing from the AnalysisStatusCode Enum, and it was observed as a valid status from my on-premise instance.

The FamilyType and Verdict enums will assist with integration development.