### PR TITLE
fix(tests): replace mock_open with real BytesIO for file uploads

### DIFF
--- a/tests/unit/base_test.py
+++ b/tests/unit/base_test.py
@@ -1,7 +1,9 @@
 import datetime
+import io
 import time
 import unittest
 from http import HTTPStatus
+from unittest.mock import MagicMock
 
 import responses
 
@@ -10,6 +12,10 @@ from intezer_sdk import errors
 from intezer_sdk.api import IntezerApiClient
 from intezer_sdk.api import raise_for_status
 from intezer_sdk.api import set_global_api
+
+
+def mock_open_bytes(data: bytes = b'data') -> MagicMock:
+    return MagicMock(side_effect=lambda *args, **kwargs: io.BytesIO(data))
 
 
 class BaseTest(unittest.TestCase):

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -10,6 +10,7 @@ from intezer_sdk import consts
 from intezer_sdk import errors
 from intezer_sdk.file import File
 from tests.unit.base_test import BaseTest
+from tests.unit.base_test import mock_open_bytes
 
 
 class FileSpec(BaseTest):
@@ -87,7 +88,7 @@ class FileSpec(BaseTest):
                 json={'result_url': '/files/index/testindex'})
             file_obj = File(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 file_obj.index(consts.IndexType.TRUSTED)
 

--- a/tests/unit/test_file_analysis.py
+++ b/tests/unit/test_file_analysis.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 import uuid
 from http import HTTPStatus
-from unittest.mock import mock_open
 from unittest.mock import patch
 
 import requests
@@ -20,6 +19,7 @@ from intezer_sdk.consts import OnPremiseVersion
 from intezer_sdk.endpoint_analysis import EndpointAnalysis
 from intezer_sdk.sub_analysis import SubAnalysis
 from tests.unit.base_test import BaseTest
+from tests.unit.base_test import mock_open_bytes
 
 
 class FileAnalysisSpec(BaseTest):
@@ -48,7 +48,7 @@ class FileAnalysisSpec(BaseTest):
                      json={'result_url': 'a/sd/asd'})
             analysis = FileAnalysis(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send()
 
@@ -70,7 +70,7 @@ class FileAnalysisSpec(BaseTest):
             analysis = FileAnalysis(file_path='a',
                                     code_item_type='memory_module')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send()
 
@@ -105,7 +105,7 @@ class FileAnalysisSpec(BaseTest):
                      json={'result': {'analysis_id': 'asd'}, 'status': 'succeeded'})
             analysis = FileAnalysis(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -126,7 +126,7 @@ class FileAnalysisSpec(BaseTest):
             analysis = FileAnalysis(file_path='a')
             wait = 1
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 start = datetime.datetime.utcnow()
                 analysis.send(wait=wait)
@@ -149,7 +149,7 @@ class FileAnalysisSpec(BaseTest):
                      json={'result': {'analysis_id': 'asd'}, 'status': 'succeeded'})
             analysis = FileAnalysis(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send()
                 analysis.wait_for_completion()
@@ -176,7 +176,7 @@ class FileAnalysisSpec(BaseTest):
                      json={'result': {'analysis_id': 'asd'}, 'status': 'succeeded'})
             analysis = FileAnalysis(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send()
                 analysis.check_status()
@@ -198,7 +198,7 @@ class FileAnalysisSpec(BaseTest):
                      status=HTTPStatus.OK,
                      json={'result': {'analysis_id': 'asd'}, 'status': 'succeeded'})
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -242,7 +242,7 @@ class FileAnalysisSpec(BaseTest):
                      status=HTTPStatus.OK,
                      json={'result': 'ioc_report'})
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 iocs = analysis.iocs
@@ -267,7 +267,7 @@ class FileAnalysisSpec(BaseTest):
                      status=HTTPStatus.OK,
                      json={'result': 'ttps_report'})
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 ttps = analysis.dynamic_ttps
@@ -301,7 +301,7 @@ class FileAnalysisSpec(BaseTest):
                      url=f'{self.full_url}/analyses/asd/dynamic-ttps',
                      status=HTTPStatus.NOT_FOUND)
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 self.assertIsNone(analysis.dynamic_ttps)
@@ -321,7 +321,7 @@ class FileAnalysisSpec(BaseTest):
                      url=f'{self.full_url}/analyses/asd/dynamic-ttps',
                      status=405)
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 with self.assertRaises(requests.HTTPError):
@@ -343,7 +343,7 @@ class FileAnalysisSpec(BaseTest):
                      status=405,
                      json={'result': 'ioc_report'})
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 with self.assertRaises(requests.HTTPError):
@@ -365,7 +365,7 @@ class FileAnalysisSpec(BaseTest):
                      status=HTTPStatus.NOT_FOUND,
                      json={'result': 'ioc_report'})
             analysis = FileAnalysis(file_path='a')
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
                 self.assertIsNone(analysis.iocs)
@@ -384,7 +384,7 @@ class FileAnalysisSpec(BaseTest):
             analysis = FileAnalysis(file_path='a',
                                     disable_dynamic_unpacking=True,
                                     disable_static_unpacking=True)
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -412,7 +412,7 @@ class FileAnalysisSpec(BaseTest):
                                     file_name='b.zip',
                                     zip_password='asd')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -440,7 +440,7 @@ class FileAnalysisSpec(BaseTest):
                                     file_name='b.zip',
                                     sandbox_command_line_arguments='-c hello')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -490,7 +490,7 @@ class FileAnalysisSpec(BaseTest):
             analysis = FileAnalysis(file_stream=__file__,
                                     zip_password='asd')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -517,7 +517,7 @@ class FileAnalysisSpec(BaseTest):
             analysis = FileAnalysis(file_path='a',
                                     zip_password='asd')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 
@@ -935,7 +935,7 @@ class FileAnalysisSpec(BaseTest):
                      json={'result': {'analysis_id': 'asd'}, 'status': 'succeeded'})
             analysis = FileAnalysis(file_path='a')
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 analysis.send(wait=True)
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,6 +1,5 @@
 import datetime
 from http import HTTPStatus
-from unittest.mock import mock_open
 from unittest.mock import patch
 
 import responses
@@ -9,6 +8,7 @@ from intezer_sdk import consts
 from intezer_sdk import errors
 from intezer_sdk.index import Index
 from tests.unit.base_test import BaseTest
+from tests.unit.base_test import mock_open_bytes
 
 
 class IndexSpec(BaseTest):
@@ -86,7 +86,7 @@ class IndexSpec(BaseTest):
                      json={'result_url': '/files/index/testindex'})
             index = Index(file_path='a', index_as=consts.IndexType.TRUSTED)
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 index.send()
 
@@ -162,7 +162,7 @@ class IndexSpec(BaseTest):
                            'status': 'succeeded'})
             index = Index(file_path='a', index_as=consts.IndexType.TRUSTED)
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 index.send(wait=True)
 
@@ -197,7 +197,7 @@ class IndexSpec(BaseTest):
                            'status': 'succeeded'})
             index = Index(file_path='a', index_as=consts.IndexType.TRUSTED)
 
-            with patch(self.patch_prop, mock_open(read_data='data')):
+            with patch(self.patch_prop, mock_open_bytes()):
                 # Act
                 index.send()
                 index.check_status()


### PR DESCRIPTION
## Summary

CI on master started failing on Python 3.12 / 3.13 / 3.14 with:

\`\`\`
TypeError: a bytes-like object is required, not 'MagicMock'
  at urllib3/filepost.py:81  ->  body.write(data)
\`\`\`

\`requests\` 2.34 tightened the file-upload code path from
\`hasattr(fp, 'read')\` to \`isinstance(fp, _SupportsRead)\`. Under
Python 3.12+, \`MagicMock\` no longer satisfies the \`_SupportsRead\`
\`Protocol\` isinstance check, so the mock from
\`mock_open(read_data='data')\` falls through to urllib3 as-is.

## Fix

- Adds a \`mock_open_bytes()\` helper in \`tests/unit/base_test.py\` that
  returns a fresh \`io.BytesIO\` per call — a real file-like that passes
  the Protocol check.
- Replaces the upload-path \`mock_open(read_data='data')\` sites in
  \`test_file_analysis.py\`, \`test_index.py\`, and \`test_file.py\` with it.
- Download-path tests in \`test_file.py\` that assert on
  \`mock_file().write\` calls keep using \`mock_open()\` (they don't go
  through the broken code path).

No SDK code changes; tests only.

## Test plan

- [x] CI green on all five Python versions (3.10 - 3.14).
- [x] \`pytest\` passes locally on Python 3.12 (228/228).